### PR TITLE
Refactor : 무한스크롤 게시글 분리

### DIFF
--- a/src/@types/post.type.ts
+++ b/src/@types/post.type.ts
@@ -3,6 +3,11 @@ export interface Post {
   imageUrl: string;
 }
 
+export interface IPost {
+  id: number;
+  imageUrl: string;
+}
+
 export type Popular = {
   address_name: string;
   content: string;

--- a/src/components/Main/AllPost.tsx
+++ b/src/components/Main/AllPost.tsx
@@ -1,54 +1,12 @@
-import React, { useState } from "react";
-import axios from "axios";
-import { useNavigate } from "react-router-dom";
-import { Post } from "../../@types/post.type";
-import useIntersectionObserver from "../../hooks/useIntersectionObserver";
+import React from "react";
+import InfinityPost from "components/common/post/InfinityPost";
 
-export function AllPost() {
-  const navigate = useNavigate();
-  const [post, setPost] = useState<Post[] | null>(null);
-  const [page, setPage] = useState(0);
-  const [checkLast, setcheckLast] = useState<boolean>();
-
-  const routePost = (id: number) => {
-    navigate(`detail/${String(id)}`);
-  };
-
-  const getData = async () => {
-    const posts = await axios.get(
-      `${process.env.REACT_APP_ENDPOINT}user/board/posts?page=${page}`
-    );
-    const newPosts = posts.data.content;
-    setPost((prevPosts) => Array.from(prevPosts || []).concat(newPosts));
-    setPage((prevPage) => prevPage + 1);
-    setcheckLast(posts.data.last);
-  };
-
-  const target = useIntersectionObserver(async (entry: any, observer: any) => {
-    await getData();
-  });
+export function AllPost(): React.ReactElement {
+  const API_URL = "user/board/posts?page=0";
 
   return (
     <>
-      <div className="flex justify-center text-[20px] h-[70px] items-center">
-        새로 작성된 아티클을 확인해보세요
-      </div>
-      <div className="flex flex-wrap flex-column w-[390px]">
-        {post
-          ? post.map((item) => {
-              return (
-                <img
-                  src={item.imageUrl}
-                  alt="이미지"
-                  className="w-[120px] h-[169px] my-[2px] mx-[1px] hover:scale-110 transition-transform ease-in-out duration-500"
-                  key={item.id}
-                  onClick={() => routePost(item.id)}
-                />
-              );
-            })
-          : null}
-      </div>
-      {checkLast ? null : <div ref={target} className="h-[90px]" />}
+      <InfinityPost url={API_URL} />
     </>
   );
 }

--- a/src/components/common/post/InfinityPost.tsx
+++ b/src/components/common/post/InfinityPost.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import useIntersectionObserver from "hooks/useIntersectionObserver";
+import { IPost } from "../../../@types/post.type";
+
+export function InfinityPost(url: any): React.ReactElement {
+  const navigate = useNavigate();
+  const [post, setPost] = useState<IPost[] | null>(null);
+  const [page, setPage] = useState(0);
+  const [checkLast, setcheckLast] = useState<boolean>();
+  const index = url.url.indexOf("=");
+  const API_ADDRESS = url.url.substring(0, index + 1);
+
+  const routePost = (id: number) => {
+    navigate(`detail/${String(id)}`);
+  };
+
+  const getData = async () => {
+    const posts = await axios.get(
+      `${process.env.REACT_APP_ENDPOINT}${API_ADDRESS}${page}`
+    );
+    const newPosts = posts.data.content;
+    setPost((prevPosts) => Array.from(prevPosts || []).concat(newPosts));
+    setPage((prevPage) => prevPage + 1);
+    setcheckLast(posts.data.last);
+  };
+
+  const target = useIntersectionObserver(async (entry: any, observer: any) => {
+    await getData();
+  });
+
+  return (
+    <>
+      <div className="flex justify-center text-[20px] h-[70px] items-center">
+        새로 작성된 아티클을 확인해보세요
+      </div>
+      <div className="flex flex-wrap flex-column w-[390px]">
+        {post
+          ? post.map((item) => {
+              return (
+                <img
+                  src={item.imageUrl}
+                  alt="이미지"
+                  className="w-[120px] h-[169px] my-[2px] mx-[1px] hover:scale-110 transition-transform ease-in-out duration-500"
+                  key={item.id}
+                  onClick={() => routePost(item.id)}
+                />
+              );
+            })
+          : null}
+      </div>
+      {checkLast ? null : <div ref={target} className="h-[90px]" />}
+    </>
+  );
+}
+
+export default InfinityPost;


### PR DESCRIPTION
1. 메인페이지 외 다른 페이지에서도 무한스크롤 게시글을 사용해야하는 경우가 있어서 분리했습니다.

InfinityPost.tsx props로 API_URL만 내려주시면 되고 엔드포인트 이후 값 넣어주시면 됩니다.
```tsx
import InfinityPost from "components/common/post/InfinityPost";

<InfinityPost url={API_URL} />
```

2. post.type.ts 변수 명 Post[] -> IPost[]로 변경했습니다. 인터페이스 참조하시는 분은 변경 부탁드립니다.