### PR TITLE
Refactor: axiosClient를 더 간편하게 사용하도록 수정

### DIFF
--- a/src/components/create/Description.tsx
+++ b/src/components/create/Description.tsx
@@ -23,8 +23,6 @@ export default function Description({
     setIsPopUp(!isPopUp);
   };
 
-  console.log(keyWord);
-
   return (
     <div className="flex flex-col gap-4">
       <div className="py-5">

--- a/src/components/signin/SignInComponent.tsx
+++ b/src/components/signin/SignInComponent.tsx
@@ -11,10 +11,10 @@ import useAuth from "hooks/useAuth";
 const SignInComponent = () => {
   const nickname_ref = useRef<HTMLInputElement>(null);
   const password_ref = useRef<HTMLInputElement>(null);
-  const { user, login } = useAuth();
+  const { user, login, isUser } = useAuth();
   const navigate = useNavigate();
 
-  console.log(user);
+  console.log(isUser);
 
   const loginHandle = async (e: any) => {
     e.preventDefault();

--- a/src/components/signin/SignInComponent.tsx
+++ b/src/components/signin/SignInComponent.tsx
@@ -6,42 +6,58 @@ import { ReactComponent as Google } from "../../assets/google.svg";
 import { ReactComponent as Kakao } from "../../assets/kakao.svg";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import useAuth from "hooks/useAuth";
 
 const SignInComponent = () => {
   const nickname_ref = useRef<HTMLInputElement>(null);
   const password_ref = useRef<HTMLInputElement>(null);
+  const { user, login } = useAuth();
   const navigate = useNavigate();
 
-  const login = async (e: any) => {
+  console.log(user);
+
+  const loginHandle = async (e: any) => {
     e.preventDefault();
     const nickname = nickname_ref.current?.value;
     const password = password_ref.current?.value;
-    const formData = new FormData();
+
     if (!nickname || !password) {
       alert("닉네임과 비밀번호를 적어주세요!");
     } else {
-      formData.append("nickname", nickname);
-      formData.append("password", password);
       try {
-        const currentDate = Date.now().toString();
-        const res = await axios.post(
-          process.env.REACT_APP_ENDPOINT + "user/login",
-          formData
-        );
-        console.log(res);
-        if (res.status === 200) {
-          localStorage.setItem("access_token", res.data.data.accessToken);
-          localStorage.setItem("expier_time", currentDate);
-          localStorage.setItem("refresh_token", res.data.data.refreshToken);
-          localStorage.setItem("nickname", res.data.data.nickname);
-          alert("미(간)지에 오신 걸 환영합니다." + nickname + "님");
-          navigate("/");
-        }
-      } catch (err) {
-        alert("닉네임과 비밀번호를 다시 확인해주세요!");
+        await login(nickname, password);
+        alert("미(간)지에 오신 걸 환영합니다." + nickname + "님");
+        navigate("/");
+      } catch (error) {
+        console.error(error);
       }
     }
   };
+  // const formData = new FormData();
+  // if (!nickname || !password) {
+  //   alert("닉네임과 비밀번호를 적어주세요!");
+  // } else {
+  //   formData.append("nickname", nickname);
+  //   formData.append("password", password);
+  //   try {
+  //     const currentDate = Date.now().toString();
+  //     const res = await axios.post(
+  //       process.env.REACT_APP_ENDPOINT + "user/login",
+  //       formData
+  //     );
+  //     console.log(res);
+  //     if (res.status === 200) {
+  //       localStorage.setItem("access_token", res.data.data.accessToken);
+  //       localStorage.setItem("expier_time", currentDate);
+  //       localStorage.setItem("refresh_token", res.data.data.refreshToken);
+  //       localStorage.setItem("nickname", res.data.data.nickname);
+  //       alert("미(간)지에 오신 걸 환영합니다." + nickname + "님");
+  //       navigate("/");
+  //     }
+  //   } catch (err) {
+  //     alert("닉네임과 비밀번호를 다시 확인해주세요!");
+  //   }
+  // }
 
   return (
     <div className="flex flex-col justify-between h-[665px] w-[24rem] px-5 overflow-y-auto">
@@ -64,7 +80,7 @@ const SignInComponent = () => {
         </div> */}
       </div>
       <div className="flex flex-col items-center justify-center">
-        <form onSubmit={login} className="mb-[35px]">
+        <form onSubmit={loginHandle} className="mb-[35px]">
           <input
             ref={nickname_ref}
             placeholder="nickname"

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -7,14 +7,14 @@ export default function useAuth() {
   /**
    * interface: nickName, passWord
    */
-  const login = (nickName: string, password: string) => {
+  const login = async (nickName: string, password: string) => {
+    console.log(nickName, password);
     const formData = new FormData();
-    if (!nickName || !password)
-      return alert("닉네임과 비밀번호를 확인해주세요.");
+
     if (nickName && password) {
       formData.append("nickname", nickName);
       formData.append("password", password);
-      postLogin(formData).then(setUser);
+      await postLogin(formData).then(setUser);
     }
     console.log(user);
   };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,7 +6,6 @@ export default function useAuth() {
   const [user, setUser] = useState(null);
   const [isUser, setIsUser] = useState(false);
   const login = async (nickName: string, password: string) => {
-    console.log(nickName, password);
     const formData = new FormData();
 
     if (nickName && password) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,12 +1,10 @@
-import React, { useState } from "react";
+import { useEffect, useState } from "react";
+import { localTokenRepoInstance } from "repository/LocalTokenRepository";
 import { postLogin } from "services/apis/miganziService";
 
-//TODO: login, logout , 유저정보, 토큰은 api 관리
 export default function useAuth() {
   const [user, setUser] = useState(null);
-  /**
-   * interface: nickName, passWord
-   */
+  const [isUser, setIsUser] = useState(false);
   const login = async (nickName: string, password: string) => {
     console.log(nickName, password);
     const formData = new FormData();
@@ -16,7 +14,15 @@ export default function useAuth() {
       formData.append("password", password);
       await postLogin(formData).then(setUser);
     }
-    console.log(user);
   };
-  return { user, login };
+  useEffect(() => {
+    const checkToken = async () => {
+      const hasToken = await localTokenRepoInstance.getAccess();
+      if (hasToken) {
+        setIsUser(true);
+      }
+    };
+    checkToken();
+  }, [isUser]);
+  return { user, login, isUser };
 }

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,16 +1,6 @@
 import Container from "components/create/Container";
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import Footer from "components/common/Layout/Footer";
 
 export default function Create() {
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!localStorage.getItem("token")) {
-      navigate("/login");
-    }
-  }, []);
   return (
     <>
       <Container />

--- a/src/repository/LocalTokenRepository.ts
+++ b/src/repository/LocalTokenRepository.ts
@@ -32,9 +32,11 @@ export class LocalTokenRepository {
     const timeElapsed = currentTime - expierToNum;
     const isExpier = Math.floor(timeElapsed / 1000) > 1800;
 
-    const getNewAccessToken = async (refreshTokens: string) => {
+    const getNewAccessToken = async (
+      refreshToken: string
+    ): Promise<string | null> => {
       try {
-        const response = await postReIssue(refreshTokens);
+        const response = await postReIssue(refreshToken);
         return response;
       } catch (e) {
         return null;

--- a/src/services/apis/miganziService.ts
+++ b/src/services/apis/miganziService.ts
@@ -34,7 +34,7 @@ export const postBoard = async (data: {}) => {
       processData: false,
     };
 
-    const response = await axiosClient.post(url, data, { headers });
+    const response = await axiosClient.axios(url, { headers, data });
     return response;
   } catch (error) {
     throw new Error(`POST Board Error: ${error}`);
@@ -49,7 +49,10 @@ export const postLogin = async (formData: any) => {
   try {
     const url = "user/login";
     const currentDate = Date.now().toString();
-    const response = await axiosClient.post(url, {}, formData);
+    const response = await axiosClient.axios(url, {
+      method: "post",
+      data: formData,
+    });
     //@ts-ignore
     localTokenRepoInstance.setRefresh(response.data?.data?.refreshToken);
     //@ts-ignore

--- a/src/services/apis/miganziService.ts
+++ b/src/services/apis/miganziService.ts
@@ -49,7 +49,7 @@ export const postLogin = async (formData: any) => {
   try {
     const url = "user/login";
     const currentDate = Date.now().toString();
-    const response = await axiosClient.post(url, formData);
+    const response = await axiosClient.post(url, {}, formData);
     //@ts-ignore
     localTokenRepoInstance.setRefresh(response.data?.data?.refreshToken);
     //@ts-ignore
@@ -57,6 +57,8 @@ export const postLogin = async (formData: any) => {
     //@ts-ignore
     localTokenRepoInstance.setNickName(response.data?.data?.nickname);
     localStorage.setItem("expier_time", currentDate);
+    //@ts-ignore
+    console.log(response.data?.data?.nickname);
     //@ts-ignore
     return response.data?.data?.nickname;
   } catch (error) {

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -1,12 +1,4 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-// import Main from "pages/Main";
-// import Detail from "pages/Detail";
-// import Search from "pages/Search";
-// import SignIn from "pages/SignIn";
-// import Create from "pages/Create";
-// import Layout from "components/common/Layout/Layout";
-// import SignUp from "pages/SignUp";
-// import TestDetail from "pages/TestDetail";
 import {
   Main,
   Detail,
@@ -24,7 +16,10 @@ import { DeleteUser } from "components/myPage/DeleteUser";
 import { MyPosts } from "components/myPage/MyPosts";
 import { MyComents } from "components/myPage/MyComents";
 import { Alarm } from "pages/Alarm";
+import useAuth from "hooks/useAuth";
 export default function Router() {
+  const { isUser } = useAuth();
+  console.log(isUser);
   return (
     <BrowserRouter>
       <Layout>
@@ -35,8 +30,8 @@ export default function Router() {
           <Route path="/search" element={<Search />} />
           <Route path="/login" element={<SignIn />} />
           <Route path="/signup" element={<SignUp />} />
-          <Route path="/create" element={<Create />} />
-          <Route path="/user" element={<MyPage />} />
+          <Route path="/create" element={isUser ? <Create /> : <SignIn />} />
+          <Route path="/user" element={isUser ? <MyPage /> : <SignIn />} />
           <Route path="/nickname" element={<ChangeNickname />} />
           <Route path="/password" element={<ChangePassword />} />
           <Route path="/delete" element={<DeleteUser />} />
@@ -49,3 +44,4 @@ export default function Router() {
     </BrowserRouter>
   );
 }
+//expier를 체킹하는 로직을 따로 만들어야함


### PR DESCRIPTION
### before
```typescript
    const response = await axiosClient.post(url, {}, formData);
```

### after
```typescript
const response = await axiosClient.axios(url, {
      method: "post",
      data: formData,
    });
```
- 사용하는 곳에서 직관적으로 표현하기 위해서 따로 만들었지만 method 키값을 활용해도 충분할 것 같습니다.

```typescript
async get<T>(
    url: string,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, { ...options, method: "GET" });
  }

  async post<T>(
    url: string,
    headers?: any,
    data?: any,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, {
      ...options,
      headers,
      method: "POST",
      data,
    });
  }

  async put<T>(
    url: string,
    data?: any,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, { ...options, method: "PUT", data });
  }

  async delete<T>(
    url: string,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, { ...options, method: "DELETE" });
  }
}
```

